### PR TITLE
Pseudotime

### DIFF
--- a/VIPInterface.py
+++ b/VIPInterface.py
@@ -1658,9 +1658,6 @@ def pseudoPlot(data):
   if 'includePseudo' not in yml.keys():
     return("ERROR - No Pseudotime Data available.")
 
-  #curve1 = yml['dim1']
-  #curve2 = yml['dim2']
-
   # Extract Embedding Key
 
   embed = yml['pseudoEmbed']

--- a/VIPInterface.py
+++ b/VIPInterface.py
@@ -1641,19 +1641,19 @@ def detectOrg(data):
   return data
 
 def pseudoPlot(data):
-  dim1 = data["dim1"]
-  dim2 = data["dim2"]
+  #dim1 = data["dim1"]
+  #dim2 = data["dim2"]
 
-  dim1 = dim1.values()
-  dim2 = dim2.values()
+  #dim1 = dim1.values()
+  #dim2 = dim2.values()
 
-  ymlAddress = data['addr']
+  ppr.pprint('pseudoPlot start')
 
-  cwd = os.getcwd()
+  aData = createData(data)
 
-  finalAddr = cwd + ymlAddress
+  #ppr.pprint(aData)
 
-  scd = app.get_data_adaptor(url_dataroot=data['url_dataroot'],dataset=data['dataset'])
+  #scd = app.get_data_adaptor(url_dataroot=data['url_dataroot'],dataset=data['dataset'])
 
   #ppr.pprint(scd.data.obsm)
 
@@ -1661,19 +1661,25 @@ def pseudoPlot(data):
 
   #ppr.pprint(scd)
 
-  embed = []
+  #embed = []
 
-  with app.get_data_adaptor(url_dataroot=data['url_dataroot'],dataset=data['dataset']) as scD:
-    embed = scD.data.obsm["X_phate"]
+  #with app.get_data_adaptor(url_dataroot=data['url_dataroot'],dataset=data['dataset']) as scD:
+    #embed = scD.data.obsm["X_phate"]
 
   #ppr.pprint(embed)
 
-  phate1 = []
-  phate2 = []
+  #phate1 = []
+  #phate2 = []
 
-  for x in embed:
-    phate1.append(x[0])
-    phate2.append(x[1])
+  #for x in embed:
+    #phate1.append(x[0])
+    #phate2.append(x[1])
+
+  ymlAddress = data['addr']
+
+  cwd = os.getcwd()
+
+  finalAddr = cwd + ymlAddress
 
   with open(finalAddr) as f:
     yml = yaml.load(f, Loader=SafeLoader)
@@ -1681,9 +1687,10 @@ def pseudoPlot(data):
   curve1 = yml['dim1']
   curve2 = yml['dim2']
 
-  plt.scatter(phate1,phate2,label = "stars", color = "green", 
-                marker = "*",  s =30)
+  #plt.scatter(phate1,phate2,label = "stars", color = "green", 
+                #marker = "*",  s =30)
   
+  sc.pl.embedding(aData,"X_phate",return_fig=True)
   plt.plot(curve1,curve2)
 
   pseudoPlot = plt.gcf()

--- a/VIPInterface.py
+++ b/VIPInterface.py
@@ -1653,13 +1653,15 @@ def pseudoPlot(data):
   with open(finalAddr) as f:
     yml = yaml.load(f, Loader=SafeLoader)
 
-  # Extract YAML data
+  # Pseudotime Data Check
 
   if 'includePseudo' not in yml.keys():
     return("ERROR - No Pseudotime Data available.")
 
-  curve1 = yml['dim1']
-  curve2 = yml['dim2']
+  #curve1 = yml['dim1']
+  #curve2 = yml['dim2']
+
+  # Extract Embedding Key
 
   embed = yml['pseudoEmbed']
 
@@ -1674,7 +1676,15 @@ def pseudoPlot(data):
   annot = data['annot']
 
   sc.pl.embedding(aData,"X_phate",color=annot,return_fig=True)
-  plt.plot(curve1,curve2)
+
+  # Extract and Plot Pseudotime Lineages
+
+  for x in yml.keys():
+    if x.split('_')[0] == 'Lineage':
+        line = yml[x]
+        dim1 = line['dim1']
+        dim2 = line['dim2']
+        plt.plot(dim1,dim2)
 
   pseudoPlot = plt.gcf()
 

--- a/VIPInterface.py
+++ b/VIPInterface.py
@@ -1630,7 +1630,7 @@ def detectOrg(data):
 
   ymlAddress = data['addr']
 
-  cwd = "/share/cellxgene/demo/YAML"
+  cwd = os.getcwd()
 
   finalAddr = cwd + ymlAddress
 

--- a/VIPInterface.py
+++ b/VIPInterface.py
@@ -1641,39 +1641,8 @@ def detectOrg(data):
   return data
 
 def pseudoPlot(data):
-  #dim1 = data["dim1"]
-  #dim2 = data["dim2"]
-
-  #dim1 = dim1.values()
-  #dim2 = dim2.values()
-
-  ppr.pprint('pseudoPlot start')
-
-  aData = createData(data)
-
-  #ppr.pprint(aData)
-
-  #scd = app.get_data_adaptor(url_dataroot=data['url_dataroot'],dataset=data['dataset'])
-
-  #ppr.pprint(scd.data.obsm)
-
-  #embed['X_%s'%one] = pd.DataFrame(scD.data.obsm['X_%s'%one][selC][:,[0,1]],columns=['%s1'%one,'%s2'%one],index=cNames)
-
-  #ppr.pprint(scd)
-
-  #embed = []
-
-  #with app.get_data_adaptor(url_dataroot=data['url_dataroot'],dataset=data['dataset']) as scD:
-    #embed = scD.data.obsm["X_phate"]
-
-  #ppr.pprint(embed)
-
-  #phate1 = []
-  #phate2 = []
-
-  #for x in embed:
-    #phate1.append(x[0])
-    #phate2.append(x[1])
+  
+  # Read YAML File
 
   ymlAddress = data['addr']
 
@@ -1684,13 +1653,27 @@ def pseudoPlot(data):
   with open(finalAddr) as f:
     yml = yaml.load(f, Loader=SafeLoader)
 
+  # Extract YAML data
+
+  if 'includePseudo' not in yml.keys():
+    return("ERROR - No Pseudotime Data available.")
+
   curve1 = yml['dim1']
   curve2 = yml['dim2']
 
-  #plt.scatter(phate1,phate2,label = "stars", color = "green", 
-                #marker = "*",  s =30)
+  embed = yml['pseudoEmbed']
+
+  # Create AnnData Object
+
+  data['layout'] = embed
+
+  aData = createData(data)
+
+  # Plot Graph
   
-  sc.pl.embedding(aData,"X_phate",return_fig=True)
+  annot = data['annot']
+
+  sc.pl.embedding(aData,"X_phate",color=annot,return_fig=True)
   plt.plot(curve1,curve2)
 
   pseudoPlot = plt.gcf()

--- a/VIPInterface.py
+++ b/VIPInterface.py
@@ -1,3 +1,4 @@
+from turtle import color
 import requests
 import json
 import traceback
@@ -1681,7 +1682,7 @@ def pseudoPlot(data):
         line = yml[x]
         dim1 = line['dim1']
         dim2 = line['dim2']
-        plt.plot(dim1,dim2)
+        plt.plot(dim1,dim2, color="black")
 
   pseudoPlot = plt.gcf()
 

--- a/VIPInterface.py
+++ b/VIPInterface.py
@@ -298,7 +298,7 @@ def distributeTask(aTask):
     'plotBW':plotBW,
     'CPV':cellpopview,
     'CPVTable':cpvtable,
-    'ymlPARSE':detectOrg,
+    'ymlPARSE':parseYAML,
     'pseudo':pseudoPlot
   }.get(aTask,errorTask)
 
@@ -1628,11 +1628,11 @@ def cpvtable(data):
   return json.dumps(deg)
 
 
-def detectOrg(data):
+def parseYAML(data):
 
   ymlAddress = data['addr']
 
-  cwd = os.getcwd()
+  cwd = "/share/cellxgene/demo/YAML"
 
   finalAddr = cwd + ymlAddress
 
@@ -1645,14 +1645,7 @@ def pseudoPlot(data):
   
   # Read YAML File
 
-  ymlAddress = data['addr']
-
-  cwd = os.getcwd()
-
-  finalAddr = cwd + ymlAddress
-
-  with open(finalAddr) as f:
-    yml = yaml.load(f, Loader=SafeLoader)
+  yml = parseYAML(data)
 
   # Pseudotime Data Check
 

--- a/VIPInterface.py
+++ b/VIPInterface.py
@@ -297,7 +297,8 @@ def distributeTask(aTask):
     'plotBW':plotBW,
     'CPV':cellpopview,
     'CPVTable':cpvtable,
-    'ymlPARSE':detectOrg
+    'ymlPARSE':detectOrg,
+    'pseudo':pseudoPlot
   }.get(aTask,errorTask)
 
 def HELLO(data):
@@ -1638,3 +1639,53 @@ def detectOrg(data):
     data = yaml.load(f, Loader=SafeLoader)
   
   return data
+
+def pseudoPlot(data):
+  dim1 = data["dim1"]
+  dim2 = data["dim2"]
+
+  dim1 = dim1.values()
+  dim2 = dim2.values()
+
+  ymlAddress = data['addr']
+
+  cwd = os.getcwd()
+
+  finalAddr = cwd + ymlAddress
+
+  scd = app.get_data_adaptor(url_dataroot=data['url_dataroot'],dataset=data['dataset'])
+
+  #ppr.pprint(scd.data.obsm)
+
+  #embed['X_%s'%one] = pd.DataFrame(scD.data.obsm['X_%s'%one][selC][:,[0,1]],columns=['%s1'%one,'%s2'%one],index=cNames)
+
+  #ppr.pprint(scd)
+
+  embed = []
+
+  with app.get_data_adaptor(url_dataroot=data['url_dataroot'],dataset=data['dataset']) as scD:
+    embed = scD.data.obsm["X_phate"]
+
+  #ppr.pprint(embed)
+
+  phate1 = []
+  phate2 = []
+
+  for x in embed:
+    phate1.append(x[0])
+    phate2.append(x[1])
+
+  with open(finalAddr) as f:
+    yml = yaml.load(f, Loader=SafeLoader)
+
+  curve1 = yml['dim1']
+  curve2 = yml['dim2']
+
+  plt.scatter(phate1,phate2,label = "stars", color = "green", 
+                marker = "*",  s =30)
+  
+  plt.plot(curve1,curve2)
+
+  pseudoPlot = plt.gcf()
+
+  return iostreamFig(pseudoPlot)

--- a/VIPInterface.py
+++ b/VIPInterface.py
@@ -1673,7 +1673,12 @@ def pseudoPlot(data):
   
   annot = data['annot']
 
-  sc.pl.embedding(aData,"X_phate",color=annot,return_fig=True)
+  if "pseudo" in annot:
+    aData.obs[annot] = aData.obs[annot].astype(float)
+    sc.pl.embedding(aData,"X_phate",color=annot,return_fig=True,color_map="Purples")
+  else:
+    sc.pl.embedding(aData,"X_phate",color=annot,return_fig=True)
+
 
   # Extract and Plot Pseudotime Lineages
 

--- a/interface.html
+++ b/interface.html
@@ -548,6 +548,7 @@
       <button class="tablinks" onclick="selFun(event, 'STACBAR')">Stacked Barplot</button>
       <button class="tablinks" onclick="selFun(event, 'GD')">Gene Detected</button>
       <button class="tablinks" onclick="selFun(event, 'CellPopView');getAllCells();detectOrganism()">Cell Population View</button>
+      <button class="tablinks" onclick="selFun(event, 'Pseudo')">Pseudotime Inference</button>
       <button class="tablinks" onclick="selFun(event, 'DEG');defaultTopSel('DEGtop','DEGtopBT1');detectOrganism()">DEG</button>
       <button id="preDEGpanelBT" class="tablinks" onclick="selFun(event, 'preDEGpanel');defaultTopSel('DEG','DEGlinksPlot')" style="display: none;">Pre-Computed DEG</button>
       <button class="tablinks" onclick="selFun(event, 'MARK')">Marker Genes</button>
@@ -667,6 +668,15 @@
       <p></p>
       <table id="CPVdatatable" class="display"></table>
     </div><!--CellPopView-->
+
+    <div id="Pseudo" class="tabcontent">
+      <div id="PseudotimeInput">
+        <h3>For a given cell population, compare gene expression between two conditions:</h3>
+        <p>Select cell embedding:
+        <select id="pseudo_cell_embed" onclick="pseudoPlot()"></select></p>
+      </div>
+      <button class="pseudoAnalysis"><b>Pseudotime Plot</b></button>
+    </div><!--Pseudo-->
 
     <div id="GD" class=tabcontent>
       <div id="GDinput">
@@ -2185,11 +2195,13 @@ function init(){
     //add layout to EMBED, DUAL, and CLI checkbox
     var embedLay = document.getElementById("EMBEDlayout");
     var dualLay = document.getElementById("DUALlayout");
+    var pseudoLay = document.getElementById("pseudo_cell_embed");
     htmlCheck="";
     for(const ix of Object.keys(window.store.getState().annoMatrix.schema.layout.obs)){
       var one = window.store.getState().annoMatrix.schema.layout.obs[ix].name
       embedLay.add(createOpt(one));
       dualLay.add(createOpt(one));
+      pseudoLay.add(createOpt(one));
       htmlCheck += '<label><input class="eIDlayouts" type="checkbox" value="'+one+'"/> '+one+' </label>';
     }
     $('#CLIlayout').html(htmlCheck.replace(/eID/g,'CLI'));
@@ -5577,13 +5589,19 @@ function CellPopTable(){
   } 
 }
 
+function pseudoPlot(){
+
+  var embed = document.getElementById("pseudo_cell_embed").value;
+
+}
+
 var database_URL;
 var databaseSearch_URL;
 
 function detectOrganism(){
 
 var D = {'method':'ymlPARSE',
-  'addr':'/'+window.store.getState().config.displayNames.dataset+'.yml'};
+  'addr':'/YAML/'+window.store.getState().config.displayNames.dataset+'.yml'};
 
 $.ajax({
   type:"POST",
@@ -5603,12 +5621,7 @@ $.ajax({
 })
 }
 
-//window.onload = function(){
- // setTimeout(detectOrganism(), 5000);
-//}
-
 var data
-
 
 function table_to_csv(rows){
 
@@ -5805,6 +5818,49 @@ function gsDB_dropdown(){
  }
 }
 
+function lookAround(){
+  //console.log(window.store.getState().annoMatrix);
+
+  //console.log(window.store.getState().annoMatrix._gcInfo);
+
+  //console.log(window.store.getState().annoMatrix._cache);
+
+  //console.log("Overall Object");
+  //console.log(window.store.getState().annoMatrix._cache.emb);
+
+  //console.log("Extract Embedding Data");
+  //console.log(window.store.getState().annoMatrix._cache.emb._columns);
+
+  //console.log("plsWork");
+
+  //console.log(window.store.getState().annoMatrix._cache.emb.colIndex.index)
+
+  elements = window.store.getState().annoMatrix.schema.layout.obs;
+
+  console.log(elements);
+
+  console.log(window.store.getState().annoMatrix)
+
+  console.log(window.store.getState().annoMatrix._cache)
+
+  console.log(window.store.getState().annoMatrix._cache.emb.colIndex.index)
+
+  console.log(window.store.getState().annoMatrix._cache.emb.__columns)
+
+  //plsWork = JSON.stringify(window.store.getState().annoMatrix._cache.emb);
+
+  //console.log(plsWork);
+
+  //plsWork2 = JSON.parse(plsWork);
+
+  //console.log(plsWork2._columns);
+
+  
+}
+
+setTimeout(function(){
+  lookAround();
+}, 3000);
 
 function helpText(x){
   if (x=='table'){

--- a/interface.html
+++ b/interface.html
@@ -2176,6 +2176,17 @@ function init(){
     densS.add(createOpt('None'));
     densG.add(createOpt('None'));
     //--------------------------------------------------------------------------
+    // add Pseudotime Annotation
+
+    var names = window.store.getState().annoMatrix.schema.annotations.obsByName;
+
+    annots = Object.keys(names);
+
+    for(const one of annots){
+      if(one.startsWith("pseudo")){
+        pseudoAnnot.add(createOpt(one));
+      }
+    }
     
     // add gene annotation categories (CellPopViw Tab)
 

--- a/interface.html
+++ b/interface.html
@@ -548,7 +548,7 @@
       <button class="tablinks" onclick="selFun(event, 'STACBAR')">Stacked Barplot</button>
       <button class="tablinks" onclick="selFun(event, 'GD')">Gene Detected</button>
       <button class="tablinks" onclick="selFun(event, 'CellPopView');getAllCells();detectOrganism()">Cell Population View</button>
-      <button class="tablinks" onclick="selFun(event, 'Pseudo')">Pseudotime Inference</button>
+      <button class="tablinks" onclick="selFun(event, 'Pseudo');getAllCells()">Pseudotime Inference</button>
       <button class="tablinks" onclick="selFun(event, 'DEG');defaultTopSel('DEGtop','DEGtopBT1');detectOrganism()">DEG</button>
       <button id="preDEGpanelBT" class="tablinks" onclick="selFun(event, 'preDEGpanel');defaultTopSel('DEG','DEGlinksPlot')" style="display: none;">Pre-Computed DEG</button>
       <button class="tablinks" onclick="selFun(event, 'MARK')">Marker Genes</button>
@@ -5594,15 +5594,24 @@ function pseudoPlot(){
 
   console.log("function start");
 
-  phate0 = window.store.getState().annoMatrix._cache.emb.__columns[2];
-  phate1 = window.store.getState().annoMatrix._cache.emb.__columns[3];
+  //phate0 = window.store.getState().annoMatrix._cache.emb.__columns[2];
+  //phate1 = window.store.getState().annoMatrix._cache.emb.__columns[3];
+
+  var cells = AllCells;
+
+  var grp = [];
+
+
 
   var D = {
   'method':'pseudo',
   'dataset': window.store.getState().config.displayNames.dataset+'.h5ad',
   'addr':'/YAML/'+window.store.getState().config.displayNames.dataset+'.yml',
-  'dim1':phate0,
-  'dim2':phate1};
+  'layout':'phate',
+  'cells':cells,
+  'genes':[],
+  'grp':grp
+  };
 
   $.ajax({
   type:"POST",

--- a/interface.html
+++ b/interface.html
@@ -671,11 +671,12 @@
 
     <div id="Pseudo" class="tabcontent">
       <div id="PseudotimeInput">
-        <h3>For a given cell population, compare gene expression between two conditions:</h3>
+        <h3>Display Pseudotime Inference results within Cellxgene_VIP:</h3>
         <p>Select cell embedding:
-        <select id="pseudo_cell_embed" onclick="pseudoPlot()"></select></p>
+        <select id="pseudo_cell_embed"></select></p>
       </div>
-      <button class="pseudoAnalysis"><b>Pseudotime Plot</b></button>
+      <button class="pseudoAnalysis" onclick="pseudoPlot()"><b>Pseudotime Plot</b></button>
+      <p id="pseudoFig"></p>
     </div><!--Pseudo-->
 
     <div id="GD" class=tabcontent>
@@ -5591,7 +5592,33 @@ function CellPopTable(){
 
 function pseudoPlot(){
 
-  var embed = document.getElementById("pseudo_cell_embed").value;
+  console.log("function start");
+
+  phate0 = window.store.getState().annoMatrix._cache.emb.__columns[2];
+  phate1 = window.store.getState().annoMatrix._cache.emb.__columns[3];
+
+  var D = {
+  'method':'pseudo',
+  'dataset': window.store.getState().config.displayNames.dataset+'.h5ad',
+  'addr':'/YAML/'+window.store.getState().config.displayNames.dataset+'.yml',
+  'dim1':phate0,
+  'dim2':phate1};
+
+  $.ajax({
+  type:"POST",
+  url: VIPurl,
+  data:JSON.stringify(D),
+  contentType: 'application/json;charset=UTF-8',//
+  success: function(res){
+
+    showImg('pseudoFig',res);
+
+  },
+  error: function() {
+    console.log('error!');
+  }
+})
+
 
 }
 

--- a/interface.html
+++ b/interface.html
@@ -5620,7 +5620,7 @@ function pseudoPlot(){
   var D = {
   'method':'pseudo',
   'dataset': window.store.getState().config.displayNames.dataset+'.h5ad',
-  'addr':'/YAML/'+window.store.getState().config.displayNames.dataset+'.yml',
+  'addr':'/'+window.store.getState().config.displayNames.dataset+'.yml',
   'cells':cells,
   'genes':[],
   'grp':grp,

--- a/interface.html
+++ b/interface.html
@@ -672,7 +672,7 @@
     <div id="Pseudo" class="tabcontent">
       <div id="PseudotimeInput">
         <h3>Display Pseudotime Inference results within Cellxgene_VIP:</h3>
-        <p>Select an annotation category:
+        <p>Colour by:
         <select id="pseudo_cell_annot"></select></p>
       </div>
       <button class="pseudoAnalysis" onclick="pseudoPlot()"><b>Pseudotime Plot</b></button>
@@ -2176,7 +2176,8 @@ function init(){
     densS.add(createOpt('None'));
     densG.add(createOpt('None'));
     //--------------------------------------------------------------------------
-    //add gene annotation categories (CellPopViw Tab)
+    
+    // add gene annotation categories (CellPopViw Tab)
 
     var featureCats = Object.entries(store.getState().annoMatrix.schema.annotations.var.columns)
 

--- a/interface.html
+++ b/interface.html
@@ -672,11 +672,13 @@
     <div id="Pseudo" class="tabcontent">
       <div id="PseudotimeInput">
         <h3>Display Pseudotime Inference results within Cellxgene_VIP:</h3>
-        <p>Select cell embedding:
-        <select id="pseudo_cell_embed"></select></p>
+        <p>Select an annotation category:
+        <select id="pseudo_cell_annot"></select></p>
       </div>
       <button class="pseudoAnalysis" onclick="pseudoPlot()"><b>Pseudotime Plot</b></button>
+      <div id="pseudoSpin" class="loading style-2" style="visibility: hidden;"><div class="loading-wheel"></div></div>
       <p id="pseudoFig"></p>
+      <p id="pseudoNote" style="color:red;"></p>
     </div><!--Pseudo-->
 
     <div id="GD" class=tabcontent>
@@ -2151,6 +2153,7 @@ function init(){
     var tVIP = document.getElementById("tVIPgrp");
     var CPVGrp = document.getElementById("CPV_ClusterKey");
     var CPVGrp2 = document.getElementById("CPV_ConditionKey");
+    var pseudoAnnot = document.getElementById("pseudo_cell_annot");
 
     for(const one of grps){
       if (one.startsWith(">")) continue;
@@ -2168,6 +2171,7 @@ function init(){
       tVIP.add(createOpt(one));
       CPVGrp.add(createOpt(one));
       CPVGrp2.add(createOpt(one));
+      pseudoAnnot.add(createOpt(one));
     }
     densS.add(createOpt('None'));
     densG.add(createOpt('None'));
@@ -2196,13 +2200,12 @@ function init(){
     //add layout to EMBED, DUAL, and CLI checkbox
     var embedLay = document.getElementById("EMBEDlayout");
     var dualLay = document.getElementById("DUALlayout");
-    var pseudoLay = document.getElementById("pseudo_cell_embed");
+
     htmlCheck="";
     for(const ix of Object.keys(window.store.getState().annoMatrix.schema.layout.obs)){
       var one = window.store.getState().annoMatrix.schema.layout.obs[ix].name
       embedLay.add(createOpt(one));
       dualLay.add(createOpt(one));
-      pseudoLay.add(createOpt(one));
       htmlCheck += '<label><input class="eIDlayouts" type="checkbox" value="'+one+'"/> '+one+' </label>';
     }
     $('#CLIlayout').html(htmlCheck.replace(/eID/g,'CLI'));
@@ -5592,25 +5595,24 @@ function CellPopTable(){
 
 function pseudoPlot(){
 
-  console.log("function start");
-
-  //phate0 = window.store.getState().annoMatrix._cache.emb.__columns[2];
-  //phate1 = window.store.getState().annoMatrix._cache.emb.__columns[3];
-
   var cells = AllCells;
 
   var grp = [];
+  
+  var annot = document.getElementById("pseudo_cell_annot").value;
 
+  grp.push(annot);
 
+  document.getElementById("pseudoSpin").style.visibility="visible";
 
   var D = {
   'method':'pseudo',
   'dataset': window.store.getState().config.displayNames.dataset+'.h5ad',
   'addr':'/YAML/'+window.store.getState().config.displayNames.dataset+'.yml',
-  'layout':'phate',
   'cells':cells,
   'genes':[],
-  'grp':grp
+  'grp':grp,
+  'annot':annot
   };
 
   $.ajax({
@@ -5619,6 +5621,15 @@ function pseudoPlot(){
   data:JSON.stringify(D),
   contentType: 'application/json;charset=UTF-8',//
   success: function(res){
+
+    if(res.startsWith('ERROR')){
+      $("#pseudoNote").text(res);
+      document.getElementById("pseudoSpin").style.visibility="hidden";
+        return;
+      }
+    
+
+    document.getElementById("pseudoSpin").style.visibility="hidden";
 
     showImg('pseudoFig',res);
 
@@ -5853,50 +5864,6 @@ function gsDB_dropdown(){
    dbGS.add(createOpt(one));
  }
 }
-
-function lookAround(){
-  //console.log(window.store.getState().annoMatrix);
-
-  //console.log(window.store.getState().annoMatrix._gcInfo);
-
-  //console.log(window.store.getState().annoMatrix._cache);
-
-  //console.log("Overall Object");
-  //console.log(window.store.getState().annoMatrix._cache.emb);
-
-  //console.log("Extract Embedding Data");
-  //console.log(window.store.getState().annoMatrix._cache.emb._columns);
-
-  //console.log("plsWork");
-
-  //console.log(window.store.getState().annoMatrix._cache.emb.colIndex.index)
-
-  elements = window.store.getState().annoMatrix.schema.layout.obs;
-
-  console.log(elements);
-
-  console.log(window.store.getState().annoMatrix)
-
-  console.log(window.store.getState().annoMatrix._cache)
-
-  console.log(window.store.getState().annoMatrix._cache.emb.colIndex.index)
-
-  console.log(window.store.getState().annoMatrix._cache.emb.__columns)
-
-  //plsWork = JSON.stringify(window.store.getState().annoMatrix._cache.emb);
-
-  //console.log(plsWork);
-
-  //plsWork2 = JSON.parse(plsWork);
-
-  //console.log(plsWork2._columns);
-
-  
-}
-
-setTimeout(function(){
-  lookAround();
-}, 3000);
 
 function helpText(x){
   if (x=='table'){


### PR DESCRIPTION
Added a visualization option for Pseudotime results, in a new "Pseudotime Inference" tab. This tab automatically extracts the pseudotime relevant embedding, draws the pseudotime-derived cell lineage line on it, and presents it to the user.

The core functionality of the tab relies on YAML file - it is assumed that the coordinates of any cell lineages will be stored as dictionaries in the YAML file associated with the dataset, under a key starting with "Lineage".

The name of the embedding associated with the pseudotime results is also found in the YAML file, under the key "pseudoEmbed".

And finally the YAML file is expected to contain a specific key, "includePseudo".  This lets the code know if any of the other keys are present - if "includePseudo" is not found, the "Pseudotime Inference" tab plotting function automatically returns "ERROR - No Pseudotime Data available."

An example of a pseudotime compatible YAML file is attached below. 
[yamlExample.txt](https://github.com/iii-cell-atlas/cellxgene_VIP/files/9150234/yamlExample.txt)

