### PR TITLE
YAML files no longer stored in git repo

### DIFF
--- a/YAML/Pb.Combined.yml
+++ b/YAML/Pb.Combined.yml
@@ -1,5 +1,0 @@
-url: https://plasmodb.org/plasmo/app/record/gene/
-url2: https://plasmodb.org/a/app/search/transcript/GeneByLocusTag?param.ds_gene_ids.idList=
-includePseudo: True
-pseudoEmbed: umap
-includeGeneSearch: True

--- a/YAML/Tbrucei.yml
+++ b/YAML/Tbrucei.yml
@@ -1,7 +1,0 @@
-url: https://tritrypdb.org/tritrypdb/app/record/gene/
-url2: https://tritrypdb.org/a/app/search/transcript/GeneByLocusTag?param.ds_gene_ids.idList=
-includePseudo: True
-pseudoEmbed: phate
-includeTradeSeq: True
-tsAnnot: Group 
-

--- a/YAML/bsf.yml
+++ b/YAML/bsf.yml
@@ -1,9 +1,0 @@
-url: https://tritrypdb.org/tritrypdb/app/record/gene/
-url2: https://tritrypdb.org/a/app/search/transcript/GeneByLocusTag?param.ds_gene_ids.idList=
-includeDescription: true
-Description: African trypanosomes proliferate as bloodstream forms and procyclic forms in the mammal and tsetse fly midgut, respectively. Using single cell transcriptomics on unsynchronised cell populations, we have obtained high resolution cell cycle regulated transcriptomes of both procyclic and slender bloodstream form Trypanosoma brucei without prior cell sorting or synchronisation. Additionally, we describe an efficient freeze-thawing protocol that allows single cell transcriptomic analysis of cryopreserved T. brucei. Chromium from 10x genomics was used to sequence individual transcriptomes for BSF and PCF parasites. Fresh and frozen samples for each life cycle form were integrated, dimensional reduced and labelled for cell cycle phase, the results of which can be interrogated here for BSF.
-Original_Paper: <a href="https://www.nature.com">Profiling the bloodstream form and procyclic form Trypanosoma brucei cell cycle using single cell transcriptomics.</a>
-Author(s): Emma M. Briggs et al.
-table_hashtag: Tbrucei_BSF
-
-

--- a/YAML/example.yml
+++ b/YAML/example.yml
@@ -1,5 +1,0 @@
-url: https://www.ncbi.nlm.nih.gov/gene/?term=
-url2: https://www.ncbi.nlm.nih.gov/gene/?term=
-Description: Single Cell transcriptomic analysis in the mouse brain during chronic Trypanosoma brucei infection.
-Original_Paper: <a href="https://www.biorxiv.org/content/10.1101/2022.03.25.485502v2">"Integrative single cell and spatial transcriptomic analysis reveal reciprocal microglia-plasma cell crosstalk in the mouse brain during chronic Trypanosoma brucei infection."</a>
-Author(s): Juan Quintana et al.

--- a/YAML/gd_tcell.yml
+++ b/YAML/gd_tcell.yml
@@ -1,2 +1,0 @@
-url: https://www.ncbi.nlm.nih.gov/gene/?term=
-url2: https://www.ncbi.nlm.nih.gov/gene/?term=

--- a/YAML/macro.yml
+++ b/YAML/macro.yml
@@ -1,2 +1,0 @@
-url: https://www.ncbi.nlm.nih.gov/gene/?term=
-url2: https://www.ncbi.nlm.nih.gov/gene/?term=

--- a/YAML/ovine.yml
+++ b/YAML/ovine.yml
@@ -1,2 +1,0 @@
-url: https://www.ncbi.nlm.nih.gov/gene/?term=
-url2: https://www.ncbi.nlm.nih.gov/gene/?term=

--- a/YAML/pcf.yml
+++ b/YAML/pcf.yml
@@ -1,9 +1,0 @@
-url: https://tritrypdb.org/tritrypdb/app/record/gene/
-url2: https://tritrypdb.org/a/app/search/transcript/GeneByLocusTag?param.ds_gene_ids.idList=
-includeDescription: true
-Description: African trypanosomes proliferate as bloodstream forms and procyclic forms in the mammal and tsetse fly midgut, respectively. Using single cell transcriptomics on unsynchronised cell populations, we have obtained high resolution cell cycle regulated transcriptomes of both procyclic and slender bloodstream form Trypanosoma brucei without prior cell sorting or synchronisation. Additionally, we describe an efficient freeze-thawing protocol that allows single cell transcriptomic analysis of cryopreserved T. brucei. Chromium from 10x genomics was used to sequence individual transcriptomes for BSF and PCF parasites. Fresh and frozen samples for each life cycle form were integrated, dimensional reduced and labelled for cell cycle phase, the results of which can be interrogated here for PCF.
-Original_Paper: <a href="https://www.nature.com">Profiling the bloodstream form and procyclic form Trypanosoma brucei cell cycle using single cell transcriptomics.</a>
-Author(s): Emma M. Briggs et al.
-table_hashtag: Tbrucei_PCF
-
-

--- a/YAML/tbPCF.yml
+++ b/YAML/tbPCF.yml
@@ -1,2 +1,0 @@
-url: https://tritrypdb.org/tritrypdb/app/record/gene/
-url2: https://tritrypdb.org/a/app/search/transcript/GeneByLocusTag?param.ds_gene_ids.idList=

--- a/YAML/tbrucei_brain.yml
+++ b/YAML/tbrucei_brain.yml
@@ -1,5 +1,0 @@
-url: https://tritrypdb.org/tritrypdb/app/record/gene/
-url2: https://tritrypdb.org/a/app/search/transcript/GeneByLocusTag?param.ds_gene_ids.idList=
-Description: Single Cell transcriptomic analysis in the mouse brain during chronic Trypanosoma brucei infection.
-Original_Paper: <a href="https://www.biorxiv.org/content/10.1101/2022.03.25.485502v2">"Integrative single cell and spatial transcriptomic analysis reveal reciprocal microglia-plasma cell crosstalk in the mouse brain during chronic Trypanosoma brucei infection."</a>
-Author(s): Juan Quintana et al.

--- a/example.yml
+++ b/example.yml
@@ -1,0 +1,5 @@
+url: https://www.ncbi.nlm.nih.gov/gene/?term=
+url2: https://www.ncbi.nlm.nih.gov/gene/?term=
+Description: Single Cell transcriptomic analysis in the mouse brain during chronic Trypanosoma brucei infection.
+Original_Paper: <a href="https://www.biorxiv.org/content/10.1101/2022.03.25.485502v2">"Integrative single cell and spatial transcriptomic analysis reveal reciprocal microglia-plasma cell crosstalk in the mouse brain during chronic Trypanosoma brucei infection."</a>
+Author(s): Juan Quintana et al.

--- a/update.VIPInterface.sh
+++ b/update.VIPInterface.sh
@@ -7,6 +7,8 @@ fi
 strPath="$(python -c 'import site; print(site.getsitepackages()[0])')"
 strweb="${strPath}/server/common/web/static/."
 
+echo -e $strPath/server/app/
+
 cp VIPInterface.py $strPath/server/app/.
 cp interface.html $strweb
 cp vip.env $strPath/server/app/. 2>/dev/null | true
@@ -22,7 +24,6 @@ if [ -n "$1" ]; then
   cp volcano.R $strPath/server/app/.
   cp browserPlot.R $strPath/server/app/.
   cp tsPlot.R $strPath/server/app/. 
-  cp -r YAML/ $strPath/server/app/.
   if [ "$(uname -s)" = "Darwin" ]; then
     sed -i .bak "s|route(request.data,current_app.app_config, \"/tmp\")|route(request.data,current_app.app_config)|" "$strPath/server/app/app.py"
     sed -i .bak "s|MAX_LAYOUTS *= *[0-9]\+|MAX_LAYOUTS = 300|" "$strPath/server/common/constants.py"


### PR DESCRIPTION
Storing the YAML files needed for online atlases in the Git repo creates unneeded differences between branches linked to the Production server and branches linked to the Development server. The YAML files are now stored in an external directory. 