### PR TITLE
Advanced gene search 2

### DIFF
--- a/VIPInterface.py
+++ b/VIPInterface.py
@@ -307,6 +307,7 @@ def distributeTask(aTask):
     'nameSearch':gene_search,
     'functionSearch': function_search,
     'get_names_and_functions':getNamesAndFunctions,
+    'get_go_terms':get_GO_info,
     'tradeSeq':tsTable,
     'tradeSeqPlotting':tradeSeqPlot,
     'PAGA':pagaAnalysis,
@@ -1946,6 +1947,27 @@ def getNamesAndFunctions(data):
   go_process = list(adata.uns["go_processes"].keys())
 
   res = [names,functions,go_comps,go_funcs,go_process]
+
+  return json.dumps(res)
+
+def get_GO_info(data):
+
+  # Generate copy of currently loaded dataset.
+  
+  with app.get_data_adaptor() as data_adaptor: 
+    adata = data_adaptor.data.copy()
+
+  # Extract GO Information
+
+  go_comps = list(adata.uns["go_components"].keys())
+
+  go_funcs = list(adata.uns["go_functions"].keys())
+
+  go_process = list(adata.uns["go_processes"].keys())
+
+  # Send back to Server
+  
+  res = [go_comps,go_funcs,go_process]
 
   return json.dumps(res)
 

--- a/VIPInterface.py
+++ b/VIPInterface.py
@@ -1938,7 +1938,9 @@ def getNamesAndFunctions(data):
 
   functions = list(adata.uns["function_lookup_table"].keys())
 
-  res = [names,functions]
+  go_terms = list(adata.uns["go_components"].keys())
+
+  res = [names,functions,go_terms]
 
   return json.dumps(res)
 

--- a/VIPInterface.py
+++ b/VIPInterface.py
@@ -1940,13 +1940,7 @@ def getNamesAndFunctions(data):
 
   functions = list(adata.uns["function_lookup_table"].keys())
 
-  go_comps = list(adata.uns["go_components"].keys())
-
-  go_funcs = list(adata.uns["go_functions"].keys())
-
-  go_process = list(adata.uns["go_processes"].keys())
-
-  res = [names,functions,go_comps,go_funcs,go_process]
+  res = [names,functions]
 
   return json.dumps(res)
 

--- a/VIPInterface.py
+++ b/VIPInterface.py
@@ -1939,20 +1939,26 @@ def getNamesAndFunctions(data):
 
   functions = list(adata.uns["function_lookup_table"].keys())
 
-  go_terms = list(adata.uns["go_components"].keys())
+  go_comps = list(adata.uns["go_components"].keys())
 
-  res = [names,functions,go_terms]
+  go_funcs = list(adata.uns["go_functions"].keys())
+
+  go_process = list(adata.uns["go_processes"].keys())
+
+  res = [names,functions,go_comps,go_funcs,go_process]
 
   return json.dumps(res)
 
 def go_genes(data):
     
   go_term = data['go']
+  
+  go_level = data['go_level']
 
   with app.get_data_adaptor() as data_adaptor: # Generate copy of currently loaded dataset.
     adata = data_adaptor.data.copy()
 
-  go_dict = adata.uns["go_components"]
+  go_dict = adata.uns[go_level]
 
   go_genes = list(go_dict[go_term])
 

--- a/VIPInterface.py
+++ b/VIPInterface.py
@@ -315,7 +315,8 @@ def distributeTask(aTask):
     'hp_cc':hp_ClusterCompare,
     'hp_viol':hpClusterViolins,
     'get_hp':get_HostParasiteTable,
-    'hp_CM':hp_ClusterMarkers
+    'hp_CM':hp_ClusterMarkers,
+    'get_go_genes':go_genes
   }.get(aTask,errorTask)
 
 def HELLO(data):
@@ -1944,6 +1945,19 @@ def getNamesAndFunctions(data):
 
   return json.dumps(res)
 
+def go_genes(data):
+    
+  go_term = data['go']
+
+  with app.get_data_adaptor() as data_adaptor: # Generate copy of currently loaded dataset.
+    adata = data_adaptor.data.copy()
+
+  go_dict = adata.uns["go_components"]
+
+  go_genes = list(go_dict[go_term])
+
+  return json.dumps(go_genes)
+
 def hp_paraClus(data):
 
   with app.get_data_adaptor() as data_adaptor:
@@ -2187,4 +2201,4 @@ def hp_ClusterMarkers(data):
 
   return json.dumps(res)
   
-  
+

--- a/interface.html
+++ b/interface.html
@@ -708,6 +708,12 @@
       <button class="geneSearch" onclick="geneSearch('functionSearch')"><b>Search</b></button>
       <div id="geneSearchSpin" class="loading style-2" style="visibility: hidden;"><div class="loading-wheel"></div></div>
       <p id="gsFunctionNote"></p>
+      <h3>Search by GO term:</h3>
+      <p>
+      <input type="text" id="gs_gene_goTerm"></p>
+      <ul id="geneGO_Results"></ul>
+    </div>
+    <button class="geneSearch" onclick="add_GO_GeneSet()"><b>Add as Gene-Set</b></button>
     </div><!--geneSearch-->
 
     <div id="HostParasite" class="tabcontent">
@@ -5973,10 +5979,12 @@ success: function(res){
   geneName = res.replace("-","_");
   url = window.database_URL;
 
+  // Return Result as a Checkbox
   data="<a href='"+url+geneName+"' target='_blank'>"+res+"</a>";
+  checkbox = "<input type='checkbox' id='"+geneName+"' name='gene_name_checkbox' value='"+data+"'>"
  
 
-  document.getElementById(output).innerHTML = data
+  document.getElementById(output).innerHTML = checkbox;
 
 },
 error: function() {
@@ -5993,6 +6001,7 @@ error: function() {
 
 var geneNamesGS;
 var geneFunctionsGS;
+var gene_GO_terms;
 
 function get_names_and_functions(){
 
@@ -6011,6 +6020,8 @@ $.ajax({
 
     geneFunctionsGS = resLists[1];
 
+    gene_GO_terms = resLists[2];
+
   },
   error: function() {
     console.log('error!');
@@ -6026,6 +6037,9 @@ var nameResultsHTML = document.getElementById("geneNameResults")
 var geneFunctionAutoComplete = document.getElementById("gs_geneFunction")
 var functionResultsHTML = document.getElementById("geneFunctionResults")
 
+var gene_GO_AutoComplete = document.getElementById("gs_gene_goTerm")
+var goResultsHTML = document.getElementById("geneGO_Results")
+
 //Define generic autocomplete behavior for textboxes
 
 function addAutoComplete(searchbox,resultList,source){
@@ -6037,12 +6051,17 @@ function addAutoComplete(searchbox,resultList,source){
 
   if(source == "names"){
     datasource = geneNamesGS
-  }else{
+  }else if(source == "functions"){
     datasource = geneFunctionsGS
+  }else {
+    datasource = gene_GO_terms
   }
+
+  console.log(datasource)
 
   if (userInput.length > 2){
     results = getResults(userInput,datasource) //get all datasource elements matching the user input
+    console.log(results)
     resultList.style.display = "block"
     for (i = 0; i < results.length; i ++){
       resultList.innerHTML += "<li>" + results[i] + "</li>"; //add all matching elements to the results list
@@ -6068,7 +6087,9 @@ function addPopulateByClick(resultsList,searchbox){
 function getResults(input,datasource) { 
   const results = [];
   for (i = 0; i < datasource.length; i++) {
-    if (input === datasource[i].slice(0, input.length)) {
+    compareVal = datasource[i].toUpperCase();
+    //compareVal.toString()
+    if (input === compareVal.slice(0, input.length)) {
       results.push(datasource[i]);
     }
   }
@@ -6425,10 +6446,12 @@ $.ajax({
     //add autocomplete to gene name and gene function search boxes
     addAutoComplete(geneNameAutoComplete,nameResultsHTML,"names")
     addAutoComplete(geneFunctionAutoComplete,functionResultsHTML,"functions")
+    addAutoComplete(gene_GO_AutoComplete,goResultsHTML,"GO")
 
     //populate text box by clicking on autocomplete option
     addPopulateByClick(nameResultsHTML,geneNameAutoComplete)
     addPopulateByClick(functionResultsHTML,geneFunctionAutoComplete)
+    addPopulateByClick(goResultsHTML,gene_GO_AutoComplete)
 
   }
   
@@ -6549,6 +6572,72 @@ var AllCells;
 var DE_Counter = 0;
 
 function add_DEG_GeneSet(){
+  $("#ADDGsetError").text("");
+  var grpName = "DE Genes".trim();
+  
+  var grpKeys = Object.keys(window.bioGeneGrp);
+  if(grpKeys.includes(grpName)){
+    DE_Counter += 1;
+    grpName = grpName + "_" + DE_Counter;
+  }
+  
+  var definedG = [];
+  for(var i=0;i<grpKeys.length;i++){
+    definedG = definedG.concat(window.bioGeneGrp[grpKeys[i]]);
+  }
+
+  var histogram_labels = document.querySelectorAll('[data-testclass="brushable-histogram-field-name"]');
+  
+
+  var histogram_labels2 = Array.from(histogram_labels);
+  deg_results = histogram_labels2.slice(0,10);
+ 
+  gene_names = [];
+  
+  for(element of deg_results){
+    
+    gene = element.textContent;
+    
+
+    gene_names.push(gene);
+  }
+
+  var gNames = gene_names;
+  var notG = [],geneNames=[];
+  var totalG = window.store.getState().annoMatrix._cache.var.__columns[0];
+  var totalGlower = totalG.map(function(s){return s.toLowerCase();});
+  for(var i=0;i<gNames.length;i++){
+    var one = gNames[i].trim();
+    var ix = totalGlower.indexOf(one.toLowerCase());
+    if(ix !== -1){
+      var oneG = totalG[ix];
+      if (one.length<1) continue;
+      if(!definedG.includes(oneG)){
+        geneNames.push(oneG);
+      }else{
+        notG.push(one);
+      }
+    }else{
+      notG.push(one);
+    }
+  }
+  var eMsg= "";
+  if(notG[0]=='nCount_RNA'){
+    eMsg +="Error - please run DEG analysis";
+    $("#ADDGsetError").text(eMsg);
+    return;
+  }
+ 
+  window.bioGeneGrp[grpName] = geneNames;
+
+  geneNames = geneNames.concat(window.biogen);
+  geneNames = [...new Set(geneNames)];
+  window.biogen = geneNames;
+  ADDGref();
+  gsDB_dropdown();
+}
+
+function add_GO_GeneSet(){
   $("#ADDGsetError").text("");
   var grpName = "DE Genes".trim();
   

--- a/interface.html
+++ b/interface.html
@@ -714,12 +714,12 @@
           <option value="go_components">Cellular Component</option>
           <option value="go_functions">Molecular Function</option>
           <option value="go_processes">Biological Process</option></select>
-        <input type="text" id="gs_gene_goTerm"></p>
-        <p id="gsGO_FunctionNote"></p>
+        <input type="text" id="gs_goTerm"></p>
+        <p id="gs_goNote"></p>
         <button class="goe_search" onclick="get_go_genes()"><b>Get GO Term Genes</b></button>
         <button class="goe_search" onclick="add_GO_GeneSet()"><b>Add as Gene-Set</b></button>
-        <ul id="geneGO_Results"></ul>
-        <ul id="go_gene_Results"></ul>
+        <ul id="gs_go_Results"></ul>
+        <ul id="gs_go_gene_Results"></ul>
     </div><!--geneSearch-->
 
     <div id="HostParasite" class="tabcontent">
@@ -6076,15 +6076,15 @@ function get_go_genes(){
 
   go_genes = []; // remove any existing pre-computed go_genes
 
-  var go_term = document.getElementById("gs_gene_goTerm").value;
+  var go_term = document.getElementById("gs_goTerm").value;
 
   var level = document.getElementById("go_level").value;
 
-  results_list = document.getElementById("geneGO_Results");
+  results_list = document.getElementById("gs_go_Results");
 
   results_list.innerHTML = '';
 
-  go_list = document.getElementById("go_gene_Results");
+  go_list = document.getElementById("gs_go_gene_Results");
   go_list.innerHTML = '';
 
   document.getElementById("geneSearchSpin").style.visibility="visible";
@@ -6137,8 +6137,8 @@ var nameResultsHTML = document.getElementById("geneNameResults")
 var geneFunctionAutoComplete = document.getElementById("gs_geneFunction")
 var functionResultsHTML = document.getElementById("geneFunctionResults")
 
-var gene_GO_AutoComplete = document.getElementById("gs_gene_goTerm")
-var goResultsHTML = document.getElementById("geneGO_Results")
+var gene_GO_AutoComplete = document.getElementById("gs_goTerm")
+var goResultsHTML = document.getElementById("gs_go_Results")
 
 //Define generic autocomplete behavior for textboxes
 
@@ -6158,7 +6158,7 @@ function addAutoComplete(searchbox,resultList,source){
     go_level = document.getElementById("go_level").value
     datasource = eval(go_level)
     
-    go_list = document.getElementById("go_gene_Results");
+    go_list = document.getElementById("gs_go_gene_Results");
     go_list.innerHTML = '';
 
   }
@@ -6758,12 +6758,12 @@ function add_DEG_GeneSet(){
 
 function add_GO_GeneSet(){
 
-  $("#gsGO_FunctionNote").text("");
+  $("#gs_goNote").text("");
   var grpName = go_term.trim();
   
   var grpKeys = Object.keys(window.bioGeneGrp);
   if(grpKeys.includes(grpName)){
-    $("#gsGO_FunctionNote").text("Geneset already added.");
+    $("#gs_goNote").text("Geneset already added.");
     return
   }
   

--- a/interface.html
+++ b/interface.html
@@ -6009,10 +6009,6 @@ error: function() {
 
 var geneNamesGS;
 var geneFunctionsGS;
-//var gene_GO_terms;
-var go_components;
-var go_functions;
-var go_processes;
 
 function get_names_and_functions(){
 
@@ -6036,6 +6032,36 @@ $.ajax({
     go_functions = resLists[3]
 
     go_processes = resLists[4]
+
+  },
+  error: function() {
+    console.log('error!');
+  }
+})
+}
+
+var go_components;
+var go_functions;
+var go_processes;
+
+function get_go_terms(){
+
+var D = {'method':'get_go_terms'};
+
+$.ajax({
+  type:"POST",
+  url: VIPurl,
+  data:JSON.stringify(D),
+  contentType: 'application/json;charset=UTF-8',//
+  success: function(res){
+
+    resLists = JSON.parse(res)
+
+    go_components = resLists[0];
+
+    go_functions = resLists[1]
+
+    go_processes = resLists[2]
 
   },
   error: function() {
@@ -6521,6 +6547,8 @@ $.ajax({
 
   includeGeneS = res['includeGeneSearch']
 
+  include_goS = res['include_goSearch']
+
   if (includeGeneS == true){ // YAML file toggle
       
     //get gene name and function information
@@ -6529,15 +6557,23 @@ $.ajax({
     //add autocomplete to gene name and gene function search boxes
     addAutoComplete(geneNameAutoComplete,nameResultsHTML,"names")
     addAutoComplete(geneFunctionAutoComplete,functionResultsHTML,"functions")
-    addAutoComplete(gene_GO_AutoComplete,goResultsHTML,"GO")
 
     //populate text box by clicking on autocomplete option
     addPopulateByClick(nameResultsHTML,geneNameAutoComplete)
     addPopulateByClick(functionResultsHTML,geneFunctionAutoComplete)
-    addPopulateByClick(goResultsHTML,gene_GO_AutoComplete)
 
   }
   
+  if (include_goS == true){ //YAML file toggle
+
+    //retrieve go info
+    get_go_terms()
+
+    //Add Autocomplete to GO Search Box
+    addAutoComplete(gene_GO_AutoComplete,goResultsHTML,"GO")
+    addPopulateByClick(goResultsHTML,gene_GO_AutoComplete)
+
+  }
   
   includeTradeSeq = res['includeTradeSeq']
 

--- a/interface.html
+++ b/interface.html
@@ -5986,11 +5986,7 @@ success: function(res){
   geneName = res.replace("-","_");
   url = window.database_URL;
 
-  // Return Result as a Checkbox
   data="<a href='"+url+geneName+"' target='_blank'>"+res+"</a>";
-
-  //checkbox = "<input type='checkbox' id='"+geneName+"' name='gene_name_checkbox' value='"+data+"'>"
- 
 
   document.getElementById(output).innerHTML = data;
 

--- a/interface.html
+++ b/interface.html
@@ -711,9 +711,11 @@
       <h3>Search by GO term:</h3>
       <p>
       <input type="text" id="gs_gene_goTerm"></p>
+      <button class="goe_search" onclick="get_go_genes()"><b>Get GO Term Genes</b></button>
+      <button class="goe_search" onclick="add_GO_GeneSet()"><b>Add as Gene-Set</b></button>
       <ul id="geneGO_Results"></ul>
+      <ul id="go_gene_Results"></ul>
     </div>
-    <button class="geneSearch" onclick="add_GO_GeneSet()"><b>Add as Gene-Set</b></button>
     </div><!--geneSearch-->
 
     <div id="HostParasite" class="tabcontent">
@@ -1800,6 +1802,7 @@
         <p id="pagaFig"></p>
       </div>
     </div><!--PAGA-->
+
 
   </div>
 </div>
@@ -5981,10 +5984,11 @@ success: function(res){
 
   // Return Result as a Checkbox
   data="<a href='"+url+geneName+"' target='_blank'>"+res+"</a>";
-  checkbox = "<input type='checkbox' id='"+geneName+"' name='gene_name_checkbox' value='"+data+"'>"
+
+  //checkbox = "<input type='checkbox' id='"+geneName+"' name='gene_name_checkbox' value='"+data+"'>"
  
 
-  document.getElementById(output).innerHTML = checkbox;
+  document.getElementById(output).innerHTML = data;
 
 },
 error: function() {
@@ -6029,6 +6033,58 @@ $.ajax({
 })
 }
 
+var go_genes;
+
+function get_go_genes(){
+
+  var go_term = document.getElementById("gs_gene_goTerm").value;
+
+  results_list = document.getElementById("geneGO_Results");
+
+  results_list.innerHTML = '';
+
+  go_list = document.getElementById("go_gene_Results");
+  go_list.innerHTML = '';
+
+  document.getElementById("geneSearchSpin").style.visibility="visible";
+
+  var D = {'method':'get_go_genes',
+           'go':go_term
+          };
+
+  $.ajax({
+    type:"POST",
+    url: VIPurl,
+    data:JSON.stringify(D),
+    contentType: 'application/json;charset=UTF-8',//
+    success: function(res){
+
+      document.getElementById("geneSearchSpin").style.visibility="hidden";
+
+      resLists = JSON.parse(res)
+
+      go_genes = resLists
+
+      for (i = 0; i < resLists.length; i ++){
+
+        gene = resLists[i].split(".")[0]
+
+        gene_hyperlink = makeLink(gene)
+
+        go_list.innerHTML += "<li>" + gene_hyperlink + "</li>"; //add all go term genes to the results list
+      
+      }
+
+    },
+    error: function() {
+
+      document.getElementById("geneSearchSpin").style.visibility="hidden";
+      console.log('error!');
+
+    }
+  })
+}
+
 //Add Autocomplete Functionality
 
 var geneNameAutoComplete = document.getElementById("gs_geneName")
@@ -6055,13 +6111,14 @@ function addAutoComplete(searchbox,resultList,source){
     datasource = geneFunctionsGS
   }else {
     datasource = gene_GO_terms
-  }
+    
+    go_list = document.getElementById("go_gene_Results");
+    go_list.innerHTML = '';
 
-  console.log(datasource)
+  }
 
   if (userInput.length > 2){
     results = getResults(userInput,datasource) //get all datasource elements matching the user input
-    console.log(results)
     resultList.style.display = "block"
     for (i = 0; i < results.length; i ++){
       resultList.innerHTML += "<li>" + results[i] + "</li>"; //add all matching elements to the results list
@@ -6073,6 +6130,8 @@ function addAutoComplete(searchbox,resultList,source){
 }
 }
 
+var go_term;
+
 //let users populate search box by clicking on an autocomplete option
 function addPopulateByClick(resultsList,searchbox){
 
@@ -6080,6 +6139,10 @@ function addPopulateByClick(resultsList,searchbox){
     const setValue = event.target.innerText;
     searchbox.value = setValue;
     this.innerHTML = "";
+
+    if(searchbox == gene_GO_AutoComplete){
+      go_term = setValue;
+    }
   };
 }
 
@@ -6638,8 +6701,13 @@ function add_DEG_GeneSet(){
 }
 
 function add_GO_GeneSet(){
+
+  console.log(go_genes);
+  console.log(go_term);
+
+
   $("#ADDGsetError").text("");
-  var grpName = "DE Genes".trim();
+  var grpName = go_term.trim();
   
   var grpKeys = Object.keys(window.bioGeneGrp);
   if(grpKeys.includes(grpName)){
@@ -6652,21 +6720,22 @@ function add_GO_GeneSet(){
     definedG = definedG.concat(window.bioGeneGrp[grpKeys[i]]);
   }
 
-  var histogram_labels = document.querySelectorAll('[data-testclass="brushable-histogram-field-name"]');
+  //var histogram_labels = document.querySelectorAll('[data-testclass="brushable-histogram-field-name"]');
   
 
-  var histogram_labels2 = Array.from(histogram_labels);
-  deg_results = histogram_labels2.slice(0,10);
+  //var histogram_labels2 = Array.from(histogram_labels);
+  //deg_results = histogram_labels2.slice(0,10);
  
-  gene_names = [];
+  //gene_names = [];
   
-  for(element of deg_results){
+  //for(element of deg_results){
     
-    gene = element.textContent;
+    //gene = element.textContent;
     
+    //gene_names.push(gene);
+  //}
 
-    gene_names.push(gene);
-  }
+  gene_names = go_genes;
 
   var gNames = gene_names;
   var notG = [],geneNames=[];
@@ -6701,6 +6770,8 @@ function add_GO_GeneSet(){
   window.biogen = geneNames;
   ADDGref();
   gsDB_dropdown();
+
+  console.log("function complete!")
 }
 
 function geneset_to_database(){

--- a/interface.html
+++ b/interface.html
@@ -6044,9 +6044,11 @@ $.ajax({
 })
 }
 
-var go_genes;
+var go_genes = new Array();
 
 function get_go_genes(){
+
+  go_genes = []; // remove any existing pre-computed go_genes
 
   var go_term = document.getElementById("gs_gene_goTerm").value;
 
@@ -6077,15 +6079,17 @@ function get_go_genes(){
 
       resLists = JSON.parse(res)
 
-      go_genes = resLists
-
       for (i = 0; i < resLists.length; i ++){
 
         gene = resLists[i].split(".")[0]
 
+        goGene = gene.replace("_","-");
+
+        go_genes.push(goGene); // add new go_genes to list
+
         gene_hyperlink = makeLink(gene)
 
-        go_list.innerHTML += "<li>" + gene_hyperlink + "</li>"; //add all go term genes to the results list
+        go_list.innerHTML += "<li>" + gene_hyperlink + "</li>"; // add all go term genes to the results list
       
       }
 

--- a/interface.html
+++ b/interface.html
@@ -715,7 +715,7 @@
           <option value="go_functions">Molecular Function</option>
           <option value="go_processes">Biological Process</option></select>
         <input type="text" id="gs_goTerm"></p>
-        <p id="gs_goNote"></p>
+        <p id="gs_goNote" style="color:red;"></p>
         <button class="goe_search" onclick="get_go_genes()"><b>Get GO Term Genes</b></button>
         <button class="goe_search" onclick="add_GO_GeneSet()"><b>Add as Gene-Set</b></button>
         <ul id="gs_go_Results"></ul>
@@ -6074,6 +6074,8 @@ var go_genes = new Array();
 
 function get_go_genes(){
 
+  if (include_goS== true){
+
   go_genes = []; // remove any existing pre-computed go_genes
 
   var go_term = document.getElementById("gs_goTerm").value;
@@ -6127,6 +6129,12 @@ function get_go_genes(){
 
     }
   })
+  }else{
+
+    $("#gs_goNote").text("No GO information available.");
+    return
+
+  }
 }
 
 //Add Autocomplete Functionality
@@ -6758,6 +6766,8 @@ function add_DEG_GeneSet(){
 
 function add_GO_GeneSet(){
 
+  if (include_goS == true){
+
   $("#gs_goNote").text("");
   var grpName = go_term.trim();
   
@@ -6807,6 +6817,13 @@ function add_GO_GeneSet(){
   window.biogen = geneNames;
   ADDGref();
   gsDB_dropdown();
+
+}else{
+  
+  $("#gs_goNote").text("No GO information available.");
+  return
+
+}
 
 }
 

--- a/interface.html
+++ b/interface.html
@@ -6023,11 +6023,6 @@ $.ajax({
 
     geneFunctionsGS = resLists[1];
 
-    go_components = resLists[2];
-
-    go_functions = resLists[3]
-
-    go_processes = resLists[4]
 
   },
   error: function() {

--- a/interface.html
+++ b/interface.html
@@ -6196,7 +6196,6 @@ function getResults(input,datasource) {
   const results = [];
   for (i = 0; i < datasource.length; i++) {
     compareVal = datasource[i].toUpperCase();
-    //compareVal.toString()
     if (input === compareVal.slice(0, input.length)) {
       results.push(datasource[i]);
     }

--- a/interface.html
+++ b/interface.html
@@ -710,7 +710,12 @@
       <p id="gsFunctionNote"></p>
       <h3>Search by GO term:</h3>
         <p>
+        <select id="go_level">
+          <option value="go_components">Cellular Component</option>
+          <option value="go_functions">Molecular Function</option>
+          <option value="go_processes">Biological Process</option></select>
         <input type="text" id="gs_gene_goTerm"></p>
+        <p id="gsGO_FunctionNote"></p>
         <button class="goe_search" onclick="get_go_genes()"><b>Get GO Term Genes</b></button>
         <button class="goe_search" onclick="add_GO_GeneSet()"><b>Add as Gene-Set</b></button>
         <ul id="geneGO_Results"></ul>
@@ -6004,7 +6009,10 @@ error: function() {
 
 var geneNamesGS;
 var geneFunctionsGS;
-var gene_GO_terms;
+//var gene_GO_terms;
+var go_components;
+var go_functions;
+var go_processes;
 
 function get_names_and_functions(){
 
@@ -6023,7 +6031,11 @@ $.ajax({
 
     geneFunctionsGS = resLists[1];
 
-    gene_GO_terms = resLists[2];
+    go_components = resLists[2];
+
+    go_functions = resLists[3]
+
+    go_processes = resLists[4]
 
   },
   error: function() {
@@ -6038,6 +6050,8 @@ function get_go_genes(){
 
   var go_term = document.getElementById("gs_gene_goTerm").value;
 
+  var level = document.getElementById("go_level").value;
+
   results_list = document.getElementById("geneGO_Results");
 
   results_list.innerHTML = '';
@@ -6048,7 +6062,8 @@ function get_go_genes(){
   document.getElementById("geneSearchSpin").style.visibility="visible";
 
   var D = {'method':'get_go_genes',
-           'go':go_term
+           'go':go_term,
+           'go_level': level
           };
 
   $.ajax({
@@ -6109,7 +6124,9 @@ function addAutoComplete(searchbox,resultList,source){
   }else if(source == "functions"){
     datasource = geneFunctionsGS
   }else {
-    datasource = gene_GO_terms
+
+    go_level = document.getElementById("go_level").value
+    datasource = eval(go_level)
     
     go_list = document.getElementById("go_gene_Results");
     go_list.innerHTML = '';
@@ -6701,38 +6718,19 @@ function add_DEG_GeneSet(){
 
 function add_GO_GeneSet(){
 
-  console.log(go_genes);
-  console.log(go_term);
-
-
-  $("#ADDGsetError").text("");
+  $("#gsGO_FunctionNote").text("");
   var grpName = go_term.trim();
   
   var grpKeys = Object.keys(window.bioGeneGrp);
   if(grpKeys.includes(grpName)){
-    DE_Counter += 1;
-    grpName = grpName + "_" + DE_Counter;
+    $("#gsGO_FunctionNote").text("Geneset already added.");
+    return
   }
   
   var definedG = [];
   for(var i=0;i<grpKeys.length;i++){
     definedG = definedG.concat(window.bioGeneGrp[grpKeys[i]]);
   }
-
-  //var histogram_labels = document.querySelectorAll('[data-testclass="brushable-histogram-field-name"]');
-  
-
-  //var histogram_labels2 = Array.from(histogram_labels);
-  //deg_results = histogram_labels2.slice(0,10);
- 
-  //gene_names = [];
-  
-  //for(element of deg_results){
-    
-    //gene = element.textContent;
-    
-    //gene_names.push(gene);
-  //}
 
   gene_names = go_genes;
 
@@ -6770,7 +6768,6 @@ function add_GO_GeneSet(){
   ADDGref();
   gsDB_dropdown();
 
-  console.log("function complete!")
 }
 
 function geneset_to_database(){

--- a/interface.html
+++ b/interface.html
@@ -709,13 +709,12 @@
       <div id="geneSearchSpin" class="loading style-2" style="visibility: hidden;"><div class="loading-wheel"></div></div>
       <p id="gsFunctionNote"></p>
       <h3>Search by GO term:</h3>
-      <p>
-      <input type="text" id="gs_gene_goTerm"></p>
-      <button class="goe_search" onclick="get_go_genes()"><b>Get GO Term Genes</b></button>
-      <button class="goe_search" onclick="add_GO_GeneSet()"><b>Add as Gene-Set</b></button>
-      <ul id="geneGO_Results"></ul>
-      <ul id="go_gene_Results"></ul>
-    </div>
+        <p>
+        <input type="text" id="gs_gene_goTerm"></p>
+        <button class="goe_search" onclick="get_go_genes()"><b>Get GO Term Genes</b></button>
+        <button class="goe_search" onclick="add_GO_GeneSet()"><b>Add as Gene-Set</b></button>
+        <ul id="geneGO_Results"></ul>
+        <ul id="go_gene_Results"></ul>
     </div><!--geneSearch-->
 
     <div id="HostParasite" class="tabcontent">


### PR DESCRIPTION
Added new functionality to the Advanced Gene Search Tab.
Users can now search a properly prepared dataset for any contained gene ontology terms (Molecular Function, Biological Process, Cellular Component).
Genes associated with a selected GO term are returned as a list, with each component formatted as a hyperlink that leads to the external database page for the given gene.
This gene-list can then added to paraCell as a Gene Set by clicking the "Add as Gene-Set" button. 